### PR TITLE
Make Mosquito Inspector embeddable at custom base paths

### DIFF
--- a/public/javascript/components/message-stream/message-stream.js
+++ b/public/javascript/components/message-stream/message-stream.js
@@ -1,8 +1,8 @@
 "use strict";
 
 import BaseComponent from '../../lib/base-component.js'
+import { basePath } from '../../lib/config.js'
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
 const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/message-stream/message-stream.html`)
 const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/message-stream/message-stream.css`)
 

--- a/public/javascript/components/message-stream/message-stream.js
+++ b/public/javascript/components/message-stream/message-stream.js
@@ -2,8 +2,9 @@
 
 import BaseComponent from '../../lib/base-component.js'
 
-const html = await BaseComponent.fetchHTML('/javascript/components/message-stream/message-stream.html')
-const css = await BaseComponent.fetchCSS('/javascript/components/message-stream/message-stream.css')
+const basePath = window.MOSQUITO_BASE_PATH || ""
+const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/message-stream/message-stream.html`)
+const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/message-stream/message-stream.css`)
 
 export default class MessageStream extends BaseComponent {
   constructor () {

--- a/public/javascript/components/overseer-list/overseer-list.js
+++ b/public/javascript/components/overseer-list/overseer-list.js
@@ -2,8 +2,8 @@
 
 import BaseComponent from '../../lib/base-component.js'
 import Builder from "../../lib/builder.js"
+import { basePath } from '../../lib/config.js'
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
 const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/overseer-list/overseer-list.html`)
 const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/overseer-list/overseer-list.css`)
 

--- a/public/javascript/components/overseer-list/overseer-list.js
+++ b/public/javascript/components/overseer-list/overseer-list.js
@@ -3,8 +3,9 @@
 import BaseComponent from '../../lib/base-component.js'
 import Builder from "../../lib/builder.js"
 
-const html = await BaseComponent.fetchHTML('/javascript/components/overseer-list/overseer-list.html')
-const css = await BaseComponent.fetchCSS('/javascript/components/overseer-list/overseer-list.css')
+const basePath = window.MOSQUITO_BASE_PATH || ""
+const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/overseer-list/overseer-list.html`)
+const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/overseer-list/overseer-list.css`)
 
 export default class OverseerList extends BaseComponent {
   constructor () {

--- a/public/javascript/components/queue-list/queue-list.js
+++ b/public/javascript/components/queue-list/queue-list.js
@@ -3,8 +3,9 @@
 import BaseComponent from '../../lib/base-component.js'
 import Builder from "../../lib/builder.js"
 
-const html = await BaseComponent.fetchHTML('/javascript/components/queue-list/queue-list.html')
-const css = await BaseComponent.fetchCSS('/javascript/components/queue-list/queue-list.css')
+const basePath = window.MOSQUITO_BASE_PATH || ""
+const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/queue-list/queue-list.html`)
+const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/queue-list/queue-list.css`)
 
 export default class QueueList extends BaseComponent {
   constructor () {

--- a/public/javascript/components/queue-list/queue-list.js
+++ b/public/javascript/components/queue-list/queue-list.js
@@ -2,8 +2,8 @@
 
 import BaseComponent from '../../lib/base-component.js'
 import Builder from "../../lib/builder.js"
+import { basePath } from '../../lib/config.js'
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
 const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/queue-list/queue-list.html`)
 const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/queue-list/queue-list.css`)
 

--- a/public/javascript/components/queue/queue.js
+++ b/public/javascript/components/queue/queue.js
@@ -1,8 +1,8 @@
 "use strict";
 
 import BaseComponent from '../../lib/base-component.js'
+import { basePath } from '../../lib/config.js'
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
 const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/queue/queue.html`)
 const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/queue/queue.css`)
 

--- a/public/javascript/components/queue/queue.js
+++ b/public/javascript/components/queue/queue.js
@@ -2,8 +2,9 @@
 
 import BaseComponent from '../../lib/base-component.js'
 
-const html = await BaseComponent.fetchHTML('/javascript/components/queue/queue.html')
-const css = await BaseComponent.fetchCSS('/javascript/components/queue/queue.css')
+const basePath = window.MOSQUITO_BASE_PATH || ""
+const html = await BaseComponent.fetchHTML(`${basePath}/javascript/components/queue/queue.html`)
+const css = await BaseComponent.fetchCSS(`${basePath}/javascript/components/queue/queue.css`)
 
 export default class Queue extends BaseComponent {
   constructor () {

--- a/public/javascript/dashboard.js
+++ b/public/javascript/dashboard.js
@@ -9,8 +9,10 @@ import Executor from "./executor.js"
 const overseerNest = new Nest(document.querySelector("#overseers"), Overseer)
 Overseer.setTemplate(document.querySelector("template#overseer"))
 
+const basePath = window.MOSQUITO_BASE_PATH || ""
 const host = window.location.host
-const eventStream = new EventStream(`ws://${host}/events`)
+const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+const eventStream = new EventStream(`${wsProtocol}//${host}${basePath}/events`)
 
 eventStream.on("broadcast", event => {
   const parts = event.channel.split(":")
@@ -25,7 +27,7 @@ eventStream.on("broadcast", event => {
 })
 
 async function fetchOverseers() {
-  fetch("/api/overseers")
+  fetch(`${basePath}/api/overseers`)
   .then(response => response.json())
   .then(({overseers}) => {
     overseers.forEach(overseerId => {

--- a/public/javascript/dashboard.js
+++ b/public/javascript/dashboard.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import EventStream from "./event_stream.js"
+import { basePath, wsBase } from "./lib/config.js"
 
 import Nest from "./nest.js"
 import Overseer from "./overseer.js"
@@ -9,10 +10,7 @@ import Executor from "./executor.js"
 const overseerNest = new Nest(document.querySelector("#overseers"), Overseer)
 Overseer.setTemplate(document.querySelector("template#overseer"))
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
-const host = window.location.host
-const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
-const eventStream = new EventStream(`${wsProtocol}//${host}${basePath}/events`)
+const eventStream = new EventStream(`${wsBase}/events`)
 
 eventStream.on("broadcast", event => {
   const parts = event.channel.split(":")

--- a/public/javascript/executor.js
+++ b/public/javascript/executor.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { basePath } from './lib/config.js'
+
 export default class Executor {
   static animationFrameLength = 50 // ms
   static template() {
@@ -85,7 +87,6 @@ export default class Executor {
     if (this.job) {
       const template = Executor.linkTemplate()
       template.querySelector("a").textContent = this.job
-      const basePath = window.MOSQUITO_BASE_PATH || ""
       template.querySelector("a").href = `${basePath}/job_run/${this.job}`
       this.detailsRow.querySelector(".working-on").textContent = ""
       this.detailsRow.querySelector(".working-on").appendChild(template)

--- a/public/javascript/executor.js
+++ b/public/javascript/executor.js
@@ -85,7 +85,8 @@ export default class Executor {
     if (this.job) {
       const template = Executor.linkTemplate()
       template.querySelector("a").textContent = this.job
-      template.querySelector("a").href = `/job_run/${this.job}`
+      const basePath = window.MOSQUITO_BASE_PATH || ""
+      template.querySelector("a").href = `${basePath}/job_run/${this.job}`
       this.detailsRow.querySelector(".working-on").textContent = ""
       this.detailsRow.querySelector(".working-on").appendChild(template)
     } else   {

--- a/public/javascript/hot_reload.js
+++ b/public/javascript/hot_reload.js
@@ -68,7 +68,6 @@ class HotReloader {
 
 export const HotReload = (path) => new HotReloader(path)
 
-const basePath = window.MOSQUITO_BASE_PATH || ""
-const host = window.location.host
-const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
-HotReload(`${wsProtocol}//${host}${basePath}/hot-reload`)
+import { wsBase } from "./lib/config.js"
+
+HotReload(`${wsBase}/hot-reload`)

--- a/public/javascript/hot_reload.js
+++ b/public/javascript/hot_reload.js
@@ -68,5 +68,7 @@ class HotReloader {
 
 export const HotReload = (path) => new HotReloader(path)
 
+const basePath = window.MOSQUITO_BASE_PATH || ""
 const host = window.location.host
-HotReload(`ws://${host}/hot-reload`)
+const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+HotReload(`${wsProtocol}//${host}${basePath}/hot-reload`)

--- a/public/javascript/lib/config.js
+++ b/public/javascript/lib/config.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const meta = document.querySelector('meta[name="mosquito-base-path"]')
+export const basePath = meta ? meta.content : ""
+
+const host = window.location.host
+const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+export const wsBase = `${wsProtocol}//${host}${basePath}`

--- a/public/javascript/overseer.js
+++ b/public/javascript/overseer.js
@@ -118,7 +118,8 @@ export default class Overseer {
   }
 
   async fetchSelf() {
-    fetch(`/api/overseers/${this.id}`)
+    const basePath = window.MOSQUITO_BASE_PATH || ""
+    fetch(`${basePath}/api/overseers/${this.id}`)
     .then(response => response.json())
     .then((overseer) => {
       this.lastActiveAt = overseer.last_active_at
@@ -126,7 +127,8 @@ export default class Overseer {
   }
 
   async fetchExecutors() {
-    fetch(`/api/overseers/${this.id}/executors`)
+    const basePath = window.MOSQUITO_BASE_PATH || ""
+    fetch(`${basePath}/api/overseers/${this.id}/executors`)
     .then(response => response.json())
     .then(({executors}) => {
       executors.forEach(executor => {

--- a/public/javascript/overseer.js
+++ b/public/javascript/overseer.js
@@ -2,6 +2,7 @@
 
 import Executor from './executor.js'
 import Nest from './nest.js'
+import { basePath } from './lib/config.js'
 
 export default class Overseer {
   static template = null
@@ -118,7 +119,6 @@ export default class Overseer {
   }
 
   async fetchSelf() {
-    const basePath = window.MOSQUITO_BASE_PATH || ""
     fetch(`${basePath}/api/overseers/${this.id}`)
     .then(response => response.json())
     .then((overseer) => {
@@ -127,7 +127,6 @@ export default class Overseer {
   }
 
   async fetchExecutors() {
-    const basePath = window.MOSQUITO_BASE_PATH || ""
     fetch(`${basePath}/api/overseers/${this.id}/executors`)
     .then(response => response.json())
     .then(({executors}) => {

--- a/public/javascript/queues.js
+++ b/public/javascript/queues.js
@@ -1,6 +1,8 @@
 import EventStream from "./event_stream.js"
+const basePath = window.MOSQUITO_BASE_PATH || ""
 const host = window.location.host
-const eventStream = new EventStream(`ws://${host}/events`)
+const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+const eventStream = new EventStream(`${wsProtocol}//${host}${basePath}/events`)
 
 eventStream.on("broadcast", message => {
   const parts = message.channel.split(":")

--- a/public/javascript/queues.js
+++ b/public/javascript/queues.js
@@ -1,8 +1,7 @@
 import EventStream from "./event_stream.js"
-const basePath = window.MOSQUITO_BASE_PATH || ""
-const host = window.location.host
-const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
-const eventStream = new EventStream(`${wsProtocol}//${host}${basePath}/events`)
+import { wsBase } from "./lib/config.js"
+
+const eventStream = new EventStream(`${wsBase}/events`)
 
 eventStream.on("broadcast", message => {
   const parts = message.channel.split(":")

--- a/src/inspector.cr
+++ b/src/inspector.cr
@@ -1,0 +1,204 @@
+require "kemal"
+require "mosquito"
+
+require "./current"
+require "./event_stream"
+require "./socket_broadcaster"
+
+Current.global(tab : Symbol = :none)
+Current.global(base_path : String = "")
+
+module Mosquito
+  class Inspector
+    getter router : Kemal::Router
+    getter base_path : String
+
+    def initialize(@base_path : String = "")
+      @router = Kemal::Router.new
+      setup_before_hooks
+      setup_html_routes
+      setup_api_routes
+      setup_websocket_routes
+    end
+
+    # Build and return a Kemal::Router ready to be mounted.
+    #
+    # Usage:
+    #
+    #   # Standalone
+    #   mount Mosquito::Inspector.router
+    #   Kemal.run
+    #
+    #   # Embedded at a prefix
+    #   inspector = Mosquito::Inspector.new("/admin/mosquito")
+    #   mount "/admin/mosquito", inspector.router
+    #   Kemal.run
+    #
+    def self.router(base_path : String = "") : Kemal::Router
+      new(base_path).router
+    end
+
+    private def setup_before_hooks
+      bp = @base_path
+      router.before_all do
+        Current.reset
+        Current.base_path = bp
+      end
+    end
+
+    private def setup_html_routes
+      router.get "/" do |env|
+        env.redirect "#{Current.base_path}/overseers"
+      end
+
+      router.get "/overseers" do |env|
+        Current.tab = :overseers
+        InspectWeb.render "overseers.html.ecr"
+      end
+
+      router.get "/queues" do |env|
+        queues = Mosquito::Api::Queue.all
+        InspectWeb.render "queues.html.ecr"
+      end
+
+      router.get "/job_run/:id" do |env|
+        job_id = env.params.url["id"]
+        job = Mosquito::Api::JobRun.new job_id
+
+        unless job.found?
+          env.response.status = HTTP::Status::UNAUTHORIZED
+        end
+
+        InspectWeb.render "job.html.ecr"
+      end
+    end
+
+    private def setup_api_routes
+      router.get "/api/overseers" do |env|
+        env.response.content_type = "application/json"
+
+        overseers = Mosquito::Api::Overseer.all
+        {
+          overseers: overseers.map(&.instance_id),
+        }.to_json
+      end
+
+      router.get "/api/overseers/:id" do |env|
+        env.response.content_type = "application/json"
+
+        id = env.params.url["id"]
+        overseer = Mosquito::Api::Overseer.new(id)
+        {
+          id:             id,
+          last_active_at: overseer.last_heartbeat.to_s,
+        }.to_json
+      end
+
+      router.get "/api/overseers/:id/executors" do |env|
+        env.response.content_type = "application/json"
+
+        id = env.params.url["id"]
+        format_executor = ->(executor : Mosquito::Api::Executor) do
+          {
+            id:                executor.instance_id,
+            current_job:       executor.current_job,
+            current_job_queue: executor.current_job_queue,
+          }
+        end
+
+        overseer = Mosquito::Api::Overseer.new(id)
+        {
+          id:        id,
+          executors: overseer.executors.map(&format_executor),
+        }.to_json
+      end
+
+      router.get "/api/executors/:id" do |env|
+        env.response.content_type = "application/json"
+
+        id = env.params.url["id"]
+        executor = Mosquito::Api::Executor.new(id)
+        {
+          executor: {
+            id:          id,
+            current_job: executor.current_job,
+          },
+        }.to_json
+      end
+    end
+
+    private def setup_websocket_routes
+      event_stream = Mosquito::Api.event_receiver
+      event_stream_clients = EventStream.new
+      queue_depth_broadcast = QueueDepthMonitor.new(1.seconds)
+
+      spawn do
+        loop do
+          select
+          when message = event_stream.receive
+            event_stream_clients.broadcast format_broadcast(message)
+          when timeout(0.5.seconds)
+          end
+
+          queue_depth_broadcast.broadcast_queue_size? do
+            event_stream_clients.broadcast queue_size_message
+          end
+        end
+      end
+
+      router.ws "/events" do |socket|
+        event_stream_clients.register socket
+      end
+    end
+
+    private def format_broadcast(broadcast : Mosquito::Backend::BroadcastMessage) : String
+      {
+        type:    "broadcast",
+        channel: broadcast.channel,
+        message: JSON.parse(broadcast.message),
+      }.to_json
+    end
+
+    private def queue_size_message : String
+      {
+        type:    "broadcast",
+        channel: "queue-summary",
+        queues:  Mosquito::Api::Queue.all.map do |queue|
+          {
+            name:    queue.name,
+            size:    queue.size,
+            details: queue.size_details,
+          }
+        end,
+      }.to_json
+    end
+  end
+end
+
+# QueueDepthMonitor throttles queue size broadcasts to a fixed interval.
+class QueueDepthMonitor
+  def initialize(@interval : Time::Span)
+    @last_broadcast_time = Time.utc
+  end
+
+  def should_broadcast?
+    Time.utc - @last_broadcast_time >= @interval
+  end
+
+  def mark_broadcasted!
+    @last_broadcast_time = Time.utc
+  end
+
+  def broadcast_queue_size?
+    if should_broadcast?
+      yield
+      mark_broadcasted!
+    end
+  end
+end
+
+module Mosquito::InspectWeb
+  macro render(file)
+    ::render({{ __DIR__ }} + "/views/" + {{ file }}, {{ __DIR__ }} + "/views/layout.html.ecr")
+  end
+end

--- a/src/views/job.html.ecr
+++ b/src/views/job.html.ecr
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for "header" do %>
-  <link rel="stylesheet" type="text/css" href="/stylesheets/job.css" />
+  <link rel="stylesheet" type="text/css" href="<%= Current.base_path %>/stylesheets/job.css" />
 <% end %>
 
 <% if job.found? %>

--- a/src/views/layout.html.ecr
+++ b/src/views/layout.html.ecr
@@ -2,12 +2,13 @@
 <html>
 <head>
   <title>Mosquito</title>
-  <link rel="stylesheet" type="text/css" href="/stylesheets/app.css">
-  <script type="module" src="/javascript/app.js"></script>
+  <link rel="stylesheet" type="text/css" href="<%= Current.base_path %>/stylesheets/app.css">
+  <script>window.MOSQUITO_BASE_PATH = "<%= Current.base_path %>";</script>
+  <script type="module" src="<%= Current.base_path %>/javascript/app.js"></script>
 
   <%= yield_content "header" %>
   <% if Kemal.config.env == "development" %>
-    <script type="module" src="/javascript/hot_reload.js"></script>
+    <script type="module" src="<%= Current.base_path %>/javascript/hot_reload.js"></script>
   <% end %>
 </head>
 <body>
@@ -22,9 +23,9 @@
   <h1>Mosquito Dashboard (<%= Current.tab %>)</h1>
 
   <div id="tabs">
-    <a href="/queues"  class="current-tab-<%= Current.tab == :queues %>">Queues</a>
-    <a href="/overseers" class="current-tab-<%= Current.tab == :overseers %>">Overseers</a>
-    <a href="/messages"  class="current-tab-<%= Current.tab == :messages %>">Messages</a>
+    <a href="<%= Current.base_path %>/queues"  class="current-tab-<%= Current.tab == :queues %>">Queues</a>
+    <a href="<%= Current.base_path %>/overseers" class="current-tab-<%= Current.tab == :overseers %>">Overseers</a>
+    <a href="<%= Current.base_path %>/messages"  class="current-tab-<%= Current.tab == :messages %>">Messages</a>
     <%= yield_content "extra_tabs" %>
   </div>
 

--- a/src/views/layout.html.ecr
+++ b/src/views/layout.html.ecr
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Mosquito</title>
+  <meta name="mosquito-base-path" content="<%= Current.base_path %>">
   <link rel="stylesheet" type="text/css" href="<%= Current.base_path %>/stylesheets/app.css">
-  <script>window.MOSQUITO_BASE_PATH = "<%= Current.base_path %>";</script>
   <script type="module" src="<%= Current.base_path %>/javascript/app.js"></script>
 
   <%= yield_content "header" %>

--- a/src/views/overseers.html.ecr
+++ b/src/views/overseers.html.ecr
@@ -1,7 +1,7 @@
 <% content_for "header" do %>
-  <script type="module" src="/javascript/dashboard.js"></script>
-  <link rel="stylesheet" href="/stylesheets/dashboard.css">
-  <link rel="stylesheet" href="/stylesheets/overseer.css">
+  <script type="module" src="<%= Current.base_path %>/javascript/dashboard.js"></script>
+  <link rel="stylesheet" href="<%= Current.base_path %>/stylesheets/dashboard.css">
+  <link rel="stylesheet" href="<%= Current.base_path %>/stylesheets/overseer.css">
 <% end %>
 
 

--- a/src/views/queues.html.ecr
+++ b/src/views/queues.html.ecr
@@ -1,5 +1,5 @@
 <% content_for "header" do %>
-  <script type="module" src="/javascript/queues.js"></script>
+  <script type="module" src="<%= Current.base_path %>/javascript/queues.js"></script>
 <% end %>
 
 <table>

--- a/web_interface.cr
+++ b/web_interface.cr
@@ -2,6 +2,17 @@ require "kemal"
 require "mosquito"
 
 require "./init"
-require "./src/web_routes"
+require "./src/inspector"
+
+# Mount the inspector dashboard at the root.
+#
+# To embed in another Kemal app at a prefix:
+#
+#   mount "/admin/mosquito", Mosquito::Inspector.router("/admin/mosquito")
+#
+mount Mosquito::Inspector.router
+
+# Development hot-reload (not part of the embeddable router)
+require "./src/http/hot_reload"
 
 Kemal.run(port: 8080)


### PR DESCRIPTION
## Summary
Refactored the Mosquito web interface to support embedding the inspector dashboard at custom base paths within existing Kemal applications, rather than only at the root level.

## Key Changes

- **New `Inspector` class** (`src/inspector.cr`): Created a mountable router that encapsulates all inspector routes, HTML, API endpoints, and WebSocket connections. Supports initialization with a custom `base_path` parameter.

- **Base path propagation**: Introduced `Current.global(base_path)` to track the inspector's base path throughout request handling, making it available to all views and API routes.

- **Updated all asset and API references**: Modified all HTML templates, JavaScript files, and API calls to use `Current.base_path` or `window.MOSQUITO_BASE_PATH` instead of hardcoded root paths (`/`).

- **WebSocket protocol handling**: Updated WebSocket connections to use the correct protocol (`ws:` or `wss:`) based on the page's protocol, and include the base path in the connection URL.

- **Simplified entry point** (`web_interface.cr`): Changed from requiring `web_routes` to using the new `Inspector.router()` API, with clear documentation on how to embed at custom paths.

- **Development hot-reload separation**: Moved hot-reload functionality to a separate require to keep it out of the embeddable router.

## Notable Implementation Details

- The `Inspector` class provides both instance-based (`new(base_path).router`) and class-method (`Inspector.router(base_path)`) APIs for flexibility.
- A `before_all` hook resets and sets the `Current.base_path` for each request, ensuring consistent path handling.
- The `QueueDepthMonitor` utility throttles queue size broadcasts to prevent excessive updates.
- All relative asset paths in views and JavaScript now use template interpolation or JavaScript variables to respect the configured base path.

https://claude.ai/code/session_01YHiXAj1iSZ8y3Jp181yPk3